### PR TITLE
updated requirement to better reflect actual requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	],
 	"require": {
 		"php": ">=5.3.3",
-		"symfony/symfony": "2.*",
+		"symfony/framework-bundle": "^2.7 || ^3.0",
 		"wrep/notificato": "~1.0"
 	},
 	"replace": {


### PR DESCRIPTION
* made it possible to use with symfony 3
* used `symfony/framework-bundle` instead of `symfony/symfony` as you only really need the framework-bundle to include this bundle
* used 2.7 as a minimum version, as older versions are no longer maintained

Linked issue: https://github.com/rickpastoor/notificato-symfony/issues/5